### PR TITLE
chore: exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "tyqs": "0.0.1-rc.2"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "lint-commit": "sh $(npm root)/@reallyland/tools/lint-commit.sh",
     "lint:build": "sh $(npm root)/@reallyland/tools/lint-build.sh -c $(npm root)/@reallyland/tools/browser/.build.eslintrc.json",
     "pre-commit": "sh $(npm root)/@reallyland/tools/pre-commit.sh",
+    "pre:enter": "npm x -y -- changeset pre enter rc",
+    "pre:exit": "npm x -y -- changeset pre exit",
     "test": "vitest --coverage",
     "version": "sh $(npm root)/@reallyland/tools/generate-changelogs.sh && git add *CHANGELOG.md"
   },


### PR DESCRIPTION
## Changes

1. Exit `changeset` prerelease mode at `v0.1.0-next.7`
1. Add `pre:enter` and `pre:exit` NPM script